### PR TITLE
Fix header responsiveness in Kommunity page

### DIFF
--- a/src/pages/Community/Community.scss
+++ b/src/pages/Community/Community.scss
@@ -3,11 +3,17 @@
 .community {
   .heading {
     position: relative;
-    margin-top: -220px;
+    margin: 70px 0 200px;
 
-    @include mobile {
-      width: 590px;
-      margin-top: -50px;
+    @include media-query-medium {
+      margin-top: 40px;
+      margin-bottom: 0;
+    }
+    @include media-query-large {
+      margin-top: -120px;
+    }
+    @include media-query-xlarge {
+      margin-top: -200px;
     }
 
     img {
@@ -16,15 +22,15 @@
 
     h3 {
       position: absolute;
-      margin-top: -180px;
       color: $third-color;
       font-size: 50px;
       font-weight: 500;
 
-      @include mobile {
-        margin-top: 20px;
-        position: static;
-        font-size: 40px;
+      @include media-query-medium {
+        margin-top: -140px;
+      }
+      @include media-query-xlarge {
+        margin-top: -180px;
       }
     }
   }


### PR DESCRIPTION
Issue #19 

Changes
1. Fixed header image overflow issue in small devices

Screenshots of small screens
1.Mobile
<img width="493" alt="Screenshot 2022-10-18 at 9 50 54 PM" src="https://user-images.githubusercontent.com/34642968/196487441-f3721be3-c2ae-47c1-819e-4fd14f74a36e.png">

2.iPad
<img width="558" alt="Screenshot 2022-10-18 at 9 50 44 PM" src="https://user-images.githubusercontent.com/34642968/196487481-182480ca-8bd2-43cc-9743-f2584446167e.png">
