### PR TITLE
[Issue #20] Footer Section - split into two columns

### DIFF
--- a/src/components/Footer/Footer.jsx
+++ b/src/components/Footer/Footer.jsx
@@ -19,41 +19,46 @@ function Footer() {
               <Fade left>
                 <div className="left col-lg-6 mb-lg-0 mb-sm-3">
                   <h3>QUICK LINKS:</h3>
-                  <Link to="/" tag={Link} className="ql">
-                    <h4>Home</h4>
-                  </Link>
+                  <div className="row">
+                    <div className="left col-12 col-sm-6">
+                      <Link to="/" tag={Link} className="ql">
+                        <h4>Home</h4>
+                      </Link>
 
-                  <Link to="/aboutus" tag={Link} className="ql">
-                    <h4>About Us</h4>
-                  </Link>
+                      <Link to="/aboutus" tag={Link} className="ql">
+                        <h4>About Us</h4>
+                      </Link>
 
-                  <Link to="/ourteam" tag={Link} className="ql">
-                    <h4>Team</h4>
-                  </Link>
+                      <Link to="/ourteam" tag={Link} className="ql">
+                        <h4>Team</h4>
+                      </Link>
 
-                  <Link to="/portfolio" tag={Link} className="ql">
-                    <h4>Portfolio</h4>
-                  </Link>
+                      <Link to="/portfolio" tag={Link} className="ql">
+                        <h4>Portfolio</h4>
+                      </Link>
 
-                  <Link to="/Kommunity" tag={Link} className="ql">
-                    <h4>Kommunity</h4>
-                  </Link>
-
-                  <Link to="/Kareer" tag={Link} className="ql">
-                    <h4>Kareer</h4>
-                  </Link>
-                  <Link to="/cancellation" tag={Link} className="ql">
-                    <h4>Cancellation</h4>
-                  </Link>
-                  <Link to="/privacy-policy" tag={Link} className="ql">
-                    <h4> Privacy Policy</h4>
-                  </Link>
-                  <Link to="/terms-of-service" tag={Link} className="ql">
-                    <h4>Terms Of Services</h4>
-                  </Link>
-                  <Link to="/support" tag={Link} className="ql">
-                    <h4>Customer Support</h4>
-                  </Link>
+                      <Link to="/Kommunity" tag={Link} className="ql">
+                        <h4>Kommunity</h4>
+                      </Link>
+                    </div>
+                    <div className="right col-12 col-sm-6 mt-0">
+                      <Link to="/Kareer" tag={Link} className="ql">
+                        <h4>Kareer</h4>
+                      </Link>
+                      <Link to="/cancellation" tag={Link} className="ql">
+                        <h4>Cancellation</h4>
+                      </Link>
+                      <Link to="/privacy-policy" tag={Link} className="ql">
+                        <h4> Privacy Policy</h4>
+                      </Link>
+                      <Link to="/terms-of-service" tag={Link} className="ql">
+                        <h4>Terms Of Services</h4>
+                      </Link>
+                      <Link to="/support" tag={Link} className="ql">
+                        <h4>Customer Support</h4>
+                      </Link>
+                    </div>
+                  </div>
                 </div>
               </Fade>
               <Fade right>


### PR DESCRIPTION
1. Changed the footer style right now all links are in a single column split into two column. 

Issue link: https://github.com/koders-in/Website/issues/20

Below is the enhanced version of footer:

<img width="1076" alt="Screenshot 2022-10-19 at 6 59 14 PM" src="https://user-images.githubusercontent.com/110656887/196704925-a72e47a9-cbb9-4f61-ba8e-4d25a9aae719.png">
