### PR TITLE
Fix blog header image style to match with other pages

### DIFF
--- a/src/components/Header/Header.scss
+++ b/src/components/Header/Header.scss
@@ -13,6 +13,7 @@
   left: 0;
   right: 0;
   height: 100px;
+  width: 100%;
 
   @media screen and (max-width: 1012px) {
     background-image: unset;

--- a/src/pages/Blog/Blog.jsx
+++ b/src/pages/Blog/Blog.jsx
@@ -9,7 +9,9 @@ function Blog() {
   return (
     <div className="blog">
       <div className="heading section-margin">
+        <Fade top>
         <img src={Image1} alt="A monitor displaying code for a webpage" />
+        </Fade>
         <div className="header-content">
           <div className="container ">
             <Fade left>

--- a/src/pages/Blog/Blog.scss
+++ b/src/pages/Blog/Blog.scss
@@ -3,48 +3,41 @@
 .blog {
   width: 100%;
 
-  //   @include mobile {
-  //     width: 590px;
-  //     overflow-x: hidden;
-  //   }
-
   .heading {
     position: relative;
-    height: 100vh;
+    height: 270px;
+    margin-bottom: 250px;
+
+    @include media-query-medium {
+      height: 400px;
+    }
+
+    @include media-query-large {
+      margin-bottom: 40px;
+    }
     img {
       width: 100%;
       height: 100%;
+      object-fit: cover;
     }
 
     .header-content {
-      position: absolute;
-      top: 50%;
       width: 100%;
+      margin-top: 20px;
+
+      @include media-query-large {
+        margin-top: -200px;
+      }
       h3 {
         padding-bottom: 50px;
         color: $third-color;
         font-size: 50px;
         font-weight: 500;
-
-        //     @include mobile {
-        //       position: static;
-        //       margin-top: 20px;
-        //       margin-left: 30px;
-        //       padding-bottom: 0px;
-        //       font-size: 40px;
-        //     }
-        //   }
       }
 
       p {
         color: $secondary-color;
         font-style: italic;
-
-        //   @include mobile {
-        //     position: static;
-        //     margin-left: 30px;
-        //     margin-top: 20px;
-        //   }
       }
     }
   }
@@ -52,10 +45,5 @@
     font-size: 35px;
     font-weight: 500;
     color: $third-color;
-
-
-    //       @include mobile {
-    //         font-size: 30px;
-    //       }
   }
 }

--- a/src/pages/Community/Community.jsx
+++ b/src/pages/Community/Community.jsx
@@ -8,7 +8,9 @@ function Community() {
   return (
     <div className="community" id="community">
       <div className="heading">
+        <Fade top>
         <img src={Image1} alt="A person holding bulb" />
+        </Fade>
         <Fade left>
           <div className="container">
             <h3>


### PR DESCRIPTION
Issue #19 

Mobile view
<img width="544" alt="Screenshot 2022-10-19 at 7 38 10 PM" src="https://user-images.githubusercontent.com/34642968/196714695-0e218894-6d16-4cc7-a04e-8557f2116013.png">

Desktop view
<img width="1680" alt="Screenshot 2022-10-19 at 7 37 54 PM" src="https://user-images.githubusercontent.com/34642968/196714714-f845a18c-4373-4bf9-b5d5-0b01986f6821.png">
