### PR TITLE
[Issue #20] Add animation on hover on footer social links

### DIFF
--- a/src/components/Footer/Footer.scss
+++ b/src/components/Footer/Footer.scss
@@ -58,7 +58,7 @@
 
       .links {
         display: flex;
-        margin-top: 10px;
+        margin-top: 20px;
 
     
 
@@ -66,7 +66,11 @@
           img {
             padding-right: 25px; 
             height: 30px;
+            transition: transform .2s;
 
+            &:hover {
+              transform: scale(1.4);
+            }
          
           }
         }


### PR DESCRIPTION
2. Add animation on hover on footer social links

Issue #20 

Below is the zoom out animation on hover of the social icons:

<img width="360" alt="Screenshot 2022-10-22 at 7 32 16 PM" src="https://user-images.githubusercontent.com/110656887/197343538-df9d0cea-7595-462a-a497-a7d75f32d880.png">
